### PR TITLE
Add executable cgi shell scripts

### DIFF
--- a/annotator/Dockerfile
+++ b/annotator/Dockerfile
@@ -22,7 +22,8 @@ RUN mkdir /var/www/brat
 
 COPY ./config/brat-v1.3_Crunchy_Frog.tar.gz /usr/local/apache2/htdocs/brat-v1.3_Crunchy_Frog.tar.gz
 RUN cd /usr/local/apache2/htdocs && tar -xvzf brat-v1.3_Crunchy_Frog.tar.gz && mv brat-v1.3_Crunchy_Frog brat
-
+COPY cgi-bin /usr/local/apache2/htdocs/brat
+RUN chmod +x /usr/local/apache2/htdocs/brat/*.sh
 
 RUN apt-get update && apt-get install -y python
 ADD ./config/httpd.conf /usr/local/apache2/conf/

--- a/annotator/cgi-bin/hello-world.sh
+++ b/annotator/cgi-bin/hello-world.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "Content-type: text/html"
+echo ""
+echo "Hello World!"

--- a/annotator/config/httpd.conf
+++ b/annotator/config/httpd.conf
@@ -294,7 +294,7 @@ DocumentRoot "/usr/local/apache2/htdocs"
     AddType application/xhtml+xml .xhtml
     AddType font/ttf .ttf
     # For CGI support
-    AddHandler cgi-script .cgi
+    AddHandler cgi-script .cgi .sh
     # Comment out the line above and uncomment the line below for FastCGI
     #AddHandler fastcgi-script fcgi
 </Directory>


### PR DESCRIPTION
@blcham @kostobog @Matthew-Kulich 

Shell scripts are now executable from URL in annotator (e.g. https://kbss.felk.cvut.cz/19msmt-demo/annotator/hello-world.sh)

Webhook is also added https://github.com/kbss-cvut/19msmt-distribution/settings/hooks/365594010